### PR TITLE
Remove Session capability

### DIFF
--- a/client/components/MainSection.tsx
+++ b/client/components/MainSection.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import {
   Panel, Well, ListGroup, ListGroupItem,
-  Glyphicon, Badge, Input, Button, ButtonToolbar
+  Glyphicon, Badge, Input, Button, ButtonToolbar, Modal
 } from 'react-bootstrap';
 
 import { IRecord, AppState, User } from '../models/pokerModels';
@@ -20,6 +20,10 @@ class MainSection extends React.Component<MainSectionProps, any> {
     super(props, context);
     this.handleDescChange = this.handleDescChange.bind(this);
   }
+  
+  state = {
+    removeSessionDialogVisible: false
+  } 
   
   // shouldComponentUpdate(nextProps: MainSectionProps, nextState) {
   //   return this.props.appState !== nextProps.appState; 
@@ -62,14 +66,46 @@ class MainSection extends React.Component<MainSectionProps, any> {
     );
   }
   
+  private removeSession() {
+      const { currentSession, currentUser, users } = this.props.appState;
+      const { leaveSession, removeSession } = this.props.actions;
+      users.toJS().forEach((u:User) =>
+        leaveSession(currentSession.sessionId, u.userId));
+      removeSession(currentSession.sessionId);
+      this.closeRemoveSessionDialog();
+  }
+  
+  private closeRemoveSessionDialog() {
+    this.setState({ removeSessionDialogVisible: false });
+  }
+  
+  private showRemoveSessionDialog() {
+    this.setState({ removeSessionDialogVisible: true });
+  }
+  
   private renderFooter() {
     const { currentSession, currentUser } = this.props.appState;
     const { leaveSession } = this.props.actions;
     let isAdmin = currentSession.adminUser === currentUser.userId;
     
+    let removeSessionDialog = 
+      <Modal key={2} show={this.state.removeSessionDialogVisible} onHide={() => this.closeRemoveSessionDialog()}>
+        <Modal.Header closeButton>
+          <Modal.Title>Remove Session?</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <p>Are you sure you want to remove this session? Any users logged into the room will have a pie thrown in their face.</p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={() => this.closeRemoveSessionDialog()}>Cancel</Button>
+          <Button bsStyle="primary" onClick={() => this.removeSession()}>Remove Session</Button>
+        </Modal.Footer>
+      </Modal>
+    
     return [
       <ButtonToolbar key={0} className="pull-right">
         { isAdmin ? [
+          <Button key="remove" bsStyle="link" bsSize="small" onClick={() => this.showRemoveSessionDialog()}>Remove Session</Button>,
           <Button key="reveal" bsStyle="success" bsSize="small">Reveal Votes</Button>,
           <Button key="clear" bsStyle="danger" bsSize="small">Clear Votes</Button> 
         ] : [] }
@@ -77,7 +113,8 @@ class MainSection extends React.Component<MainSectionProps, any> {
           Leave Session
         </Button>
       </ButtonToolbar>,
-      <div key={1} className="clearfix" />
+      <div key={1} className="clearfix" />,
+      removeSessionDialog
     ];
   }
   

--- a/client/components/MainSection.tsx
+++ b/client/components/MainSection.tsx
@@ -119,7 +119,7 @@ class MainSection extends React.Component<MainSectionProps, any> {
           Leave Session
         </Button>
         { isAdmin ? [
-          <DropdownButton bsSize="small" bsStyle="primary" title="Session Admin" id="adminDDB" onSelect={(event, eventKey) => this.adminDDBSelect(eventKey)}>
+          <DropdownButton key={2} bsSize="small" bsStyle="primary" title="Session Admin" id="adminDDB" onSelect={(event, eventKey) => this.adminDDBSelect(eventKey)}>
             <MenuItem eventKey="reveal">Reveal Votes</MenuItem>
             <MenuItem eventKey="clear">Clear Votes</MenuItem>
             <MenuItem divider />

--- a/client/components/MainSection.tsx
+++ b/client/components/MainSection.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import {
   Panel, Well, ListGroup, ListGroupItem,
-  Glyphicon, Badge, Input, Button, ButtonToolbar, Modal
+  Glyphicon, Badge, Input, Button, DropdownButton, MenuItem, ButtonToolbar, Modal
 } from 'react-bootstrap';
 
 import { IRecord, AppState, User } from '../models/pokerModels';
@@ -83,13 +83,24 @@ class MainSection extends React.Component<MainSectionProps, any> {
     this.setState({ removeSessionDialogVisible: true });
   }
   
+  private adminDDBSelect(eventKey: string) {
+    switch (eventKey) {
+      case "remove":
+        this.showRemoveSessionDialog()
+        break;
+    
+      default:
+        break;
+    }
+  }
+  
   private renderFooter() {
     const { currentSession, currentUser } = this.props.appState;
     const { leaveSession } = this.props.actions;
     let isAdmin = currentSession.adminUser === currentUser.userId;
     
     let removeSessionDialog = 
-      <Modal key={2} show={this.state.removeSessionDialogVisible} onHide={() => this.closeRemoveSessionDialog()}>
+      <Modal key={2} bsSize="small" show={this.state.removeSessionDialogVisible} onHide={() => this.closeRemoveSessionDialog()}>
         <Modal.Header closeButton>
           <Modal.Title>Remove Session?</Modal.Title>
         </Modal.Header>
@@ -104,14 +115,17 @@ class MainSection extends React.Component<MainSectionProps, any> {
     
     return [
       <ButtonToolbar key={0} className="pull-right">
-        { isAdmin ? [
-          <Button key="remove" bsStyle="link" bsSize="small" onClick={() => this.showRemoveSessionDialog()}>Remove Session</Button>,
-          <Button key="reveal" bsStyle="success" bsSize="small">Reveal Votes</Button>,
-          <Button key="clear" bsStyle="danger" bsSize="small">Clear Votes</Button> 
-        ] : [] }
         <Button bsSize="small" onClick={() => leaveSession(currentSession.sessionId, currentUser.userId)}>
           Leave Session
         </Button>
+        { isAdmin ? [
+          <DropdownButton bsSize="small" bsStyle="primary" title="Session Admin" id="adminDDB" onSelect={(event, eventKey) => this.adminDDBSelect(eventKey)}>
+            <MenuItem eventKey="reveal">Reveal Votes</MenuItem>
+            <MenuItem eventKey="clear">Clear Votes</MenuItem>
+            <MenuItem divider />
+            <MenuItem eventKey="remove">Remove Session</MenuItem>
+          </DropdownButton> 
+        ] : [] }
       </ButtonToolbar>,
       <div key={1} className="clearfix" />,
       removeSessionDialog

--- a/client/reducers/pokerReducers.ts
+++ b/client/reducers/pokerReducers.ts
@@ -30,11 +30,11 @@ export default handleActions<AppState>({
     return state.withMutations(mutable => {
       mutable.update('sessionNames', (sns:SessionNames) => 
         sns.map(sn => 
-          sn.sessionId === session.sessionId
+          session && sn.sessionId === session.sessionId
             ? sn.merge(session) : sn
         ).toList());
         
-      if (state.currentSession.sessionId === session.sessionId) {
+      if (session && state.currentSession.sessionId === session.sessionId) {
         mutable.update('currentSession', (curSession:IRecord<Session>) =>
           curSession.merge(session));
       }

--- a/client/reducers/pokerReducers.ts
+++ b/client/reducers/pokerReducers.ts
@@ -74,10 +74,19 @@ export default handleActions<AppState>({
     //console.log(action);
     const newUsers: User[] = action.payload;
     
-    // Immutable.List.merge goes by indexes, replaces items without regard to identity
-    // For now just replace all users instead, but may want to use more granular add/remove
-    // events from Firebase instead of 'value' for better performance.
-    return state.update('users', () => Immutable.List(newUsers.map(u => new UserRecord(u))));
+    if (newUsers.some((value: User, index: number, array: User[]) => {
+      return value.userId === state.currentUser.userId
+    })) {
+      // Immutable.List.merge goes by indexes, replaces items without regard to identity
+      // For now just replace all users instead, but may want to use more granular add/remove
+      // events from Firebase instead of 'value' for better performance.
+      return state.update('users', () => Immutable.List(newUsers.map(u => new UserRecord(u))));
+    } else {
+      // The user list does not contain the current user, so clear the currentSession state property
+      return state.withMutations(mutable => {
+        mutable.update('currentSession', () => new SessionRecord());
+      });
+    }
   },
   
   [UserAction.Auth]: (state:IRecord<AppState>, action:Action) => {


### PR DESCRIPTION
I did a few things to allow a session admin to remove a session. I added a "Remove Session" button, but then placed all the admin functions within a DropdownButton to save on real-estate usage in small devices. Actually, it would be nice to use the DropdownButton in small device widths and use individual buttons in larger device widths.

I added a dialog to confirm the session removal that calls leaveSession() for all session users, then calls removeSession(). All users are removed and the admin user is redirected to the session list view, but non-admin users are left in an empty room that they aren't even a room user. I wasn't sure how to get the non-admin users to redirect to the list view. There was also an error being thrown in pokerReducers.ts for non-admin users because the session object was undefined (or null, I don't really remember), so I simply modified the conditional to not throw the error.
